### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/release-docker-build-push.yaml
+++ b/.github/workflows/release-docker-build-push.yaml
@@ -18,7 +18,11 @@ jobs:
       - name: Get the latest tag
         id: get_tag
         run: |
-          TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          TAG=$(git tag --list | sort -V | tail -n 1)
+          if [ -z "$TAG" ]; then
+            echo "No tags found. Setting default tag to v0.1.0"
+            TAG="v0.1.0"
+          fi
           echo "tag=$TAG" >> $GITHUB_ENV
 
       - name: Bump version and push tag


### PR DESCRIPTION
## [v0.2.0] - 2024-11-21

### Added

- Add `--cell-barcodes` option to count reads by cell barcodes of interest.
- Add `--max-loci` option to count reads that map to a maximum number of loci.

### Changed

- Count paired reads that span the same junction only once, not twice.
- Refactor anchor length calculation in junction processing

### Fixed

- Fixed a bug that reads having softclip are not counted