### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/release-docker-build-push.yaml
+++ b/.github/workflows/release-docker-build-push.yaml
@@ -17,37 +17,30 @@ jobs:
 
       - name: Get the latest tag
         id: get_tag
-        run: |
-          TAG=$(git tag --list | sort -V | tail -n 1)
-          if [ -z "$TAG" ]; then
-            echo "No tags found. Setting default tag to v0.1.0"
-            TAG="v0.1.0"
-          fi
-          echo "tag=$TAG" >> $GITHUB_ENV
+        run: echo ::set-output name=tag::$(git describe --tags `git rev-list --tags --max-count=1`)
 
       - name: Bump version and push tag
         id: tag_version
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           NEW_TAG=$(cat VERSION)
           echo "New tag is $NEW_TAG"
-          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+          echo "::set-output name=NEW_TAG::$NEW_TAG"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git tag -a $NEW_TAG -m "Release $NEW_TAG"
-          git remote set-url origin https://${GH_PAT}@github.com/${{ github.repository }}
+          git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git push origin $NEW_TAG
+        env:
+          VERSION: ${{ steps.get_tag.outputs.tag }}
 
       - name: Debug NEW_TAG
-        run: |
-          echo "The new tag is $NEW_TAG"
+        run: echo "The new tag is $NEW_TAG"
 
       - name: Create GitHub release
         id: create_release
         uses: actions/create-release@v1.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.tag_version.outputs.NEW_TAG }}
           release_name: ${{ steps.tag_version.outputs.NEW_TAG }}


### PR DESCRIPTION
## [v0.2.0] - 2024-11-21

### Added

- Add `--cell-barcodes` option to count reads by cell barcodes of interest.
- Add `--max-loci` option to count reads that map to a maximum number of loci.

### Changed

- Count paired reads that span the same junction only once, not twice.
- Refactor anchor length calculation in junction processing

### Fixed

- Fixed a bug that reads having softclip are not counted